### PR TITLE
Update NonQueryJinqStream.java

### DIFF
--- a/api/src/org/jinq/orm/stream/NonQueryJinqStream.java
+++ b/api/src/org/jinq/orm/stream/NonQueryJinqStream.java
@@ -466,7 +466,7 @@ public class NonQueryJinqStream<T> extends LazyWrappedStream<T> implements JinqS
    @Override 
    public JinqStream<T> distinct()
    {
-      return wrap(distinct());
+      return wrap(super.distinct());
    }
 
    @Override


### PR DESCRIPTION
When the query compiler can not map a lambda to a native query and switches to the pure Java implementation, a distinct() in the NonQueryJinqStream may throw a StackOverflowError. distinct method is effectively calling itself before making any changes, so it seems like it should call super implementation, like many others.